### PR TITLE
Make API_URL a window level constant, modularize login

### DIFF
--- a/public/js/API_URL.js
+++ b/public/js/API_URL.js
@@ -1,3 +1,6 @@
 define(function () {
-    return '/api/v0';
+	//Just setting this globally so we don't have to require it.
+	//Technically breaks what requireJS is trying to do but I think this is okay.
+	window.API_URL = '/api/v0'
+	return API_URL;
 });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19,7 +19,7 @@ require.config({
        "pickalegacy": "vendor/pickadate/legacy",
        "jquery-ui-custom": "vendor/fullcalendar/lib/jquery-ui.custom.min",
        "fullcalendar": "vendor/fullcalendar/fullcalendar",
-       "magnific-popup": "vendor/magnific-popup/jquery.magnific-popup"
+       "magnific-popup": "vendor/magnific-popup/jquery.magnific-popup",
       },
       shim:    {
         'react-router-shim': {
@@ -30,6 +30,6 @@ require.config({
       jsx: {
         fileExtension: '.jsx'
        }
-      });
-
-    require(['jsx!react_components/router']);
+});
+  
+require(['API_URL', 'jsx!react_components/router'])

--- a/public/js/app_prep/ajax_setup.js
+++ b/public/js/app_prep/ajax_setup.js
@@ -1,0 +1,19 @@
+define(['jquery'], function($){
+  $.ajaxSetup({
+      beforeSend: function(xhr) {
+        // var fbStatus;
+        // FB.getLoginStatus(function(res) {
+        //   fbStatus = res.status;
+        // });
+        // if ($.cookie('access_token')) {
+          xhr.setRequestHeader("access_token", $.cookie('access_token'));
+          xhr.setRequestHeader("user_id", $.cookie('user_id'));
+        // } else {
+        //   console.log("can't send data before login or your session has timed out");
+          // localStorage.clear();
+          // document.location.href="/";
+          // alert("can't send data before login or your session has timed out");
+        // }
+      }
+  });   
+});

--- a/public/js/app_prep/fb.js
+++ b/public/js/app_prep/fb.js
@@ -1,0 +1,18 @@
+define(function(){
+	// Load FB SDK
+ 	window.fbAsyncInit = function(){
+ 		FB.init({
+			appId      : '751003924936029',
+			xfbml      : true,
+			version    : 'v2.2',
+			status     : true
+ 		}); 
+ 	};
+	(function(d, s, id){
+	 var js, fjs = d.getElementsByTagName(s)[0];
+	 if (d.getElementById(id)) {return;}
+	 js = d.createElement(s); js.id = id;
+	 js.src = "js/vendor/fb_sdk.js";
+	 fjs.parentNode.insertBefore(js, fjs);
+	}(document, 'script', 'facebook-jssdk'));
+});

--- a/public/js/app_prep/try_login.js
+++ b/public/js/app_prep/try_login.js
@@ -1,0 +1,9 @@
+define(['jquery', 'jquery-cookie', 'utils/UserUtils'], function($, cookie, UserAPI){
+    FB.getLoginStatus(function(response){
+    	if(response.status === 'connected' &&localStorage.getItem('fb_id') && $.cookie('access_token'))
+    	{
+    		UserAPI.loginToServer();
+    	}
+    })
+	
+});

--- a/public/js/react_components/calendar/_show.jsx
+++ b/public/js/react_components/calendar/_show.jsx
@@ -1,4 +1,4 @@
-define(['react', 'jquery', 'react-router', 'API_URL'], function(React, $, Router, API_URL){
+define(['react', 'jquery', 'react-router'], function(React, $, Router){
 	var Link = Router.Link
 	var ShowCalendar = React.createClass({
 

--- a/public/js/react_components/group/_show.jsx
+++ b/public/js/react_components/group/_show.jsx
@@ -1,4 +1,4 @@
-define(['react', 'jquery', 'react-router', 'API_URL', 'actions/GroupViewActions'], function(React, $, Router, API_URL, GroupViewActions){
+define(['react', 'jquery', 'react-router', 'actions/GroupViewActions'], function(React, $, Router, GroupViewActions){
 	
 	var Link = Router.Link;
 

--- a/public/js/react_components/header/_auth.jsx
+++ b/public/js/react_components/header/_auth.jsx
@@ -16,7 +16,8 @@ define(['react', 'jquery', 'jquery-cookie', 'utils/GroupWebAPIUtils', 'utils/Use
       _onchange: function() {
         this.setState(getStateFromStores());
       },
-      FBlogin: function() {
+      FBlogin: function(evt) {
+        evt.preventDefault();
         // FB.getLoginStatus(function(response) {
           // if (response.status === 'connected') {
           //   UserUtils.logIn();

--- a/public/js/react_components/main/app.jsx
+++ b/public/js/react_components/main/app.jsx
@@ -1,0 +1,22 @@
+define(['react', 'react-router', 'jsx!react_components/header/_navbar', 'jsx!react_components/sidebar/_sidebar'], function(React, Router, Navbar, Sidebar){
+	var RouteHandler = Router.RouteHandler
+
+	var App = React.createClass({
+			render: function () {
+				var style = {border: 0};
+				return(
+	        <div id="container">
+						<Navbar />
+	          <div id="main-container" className="row gutters">
+							<Sidebar />
+	          	<div id="main-panel" className="debug col span_10 cf">
+								<RouteHandler />
+							</div>
+	        	</div>
+				</div>
+				)
+			}
+		})
+
+	return App
+});

--- a/public/js/react_components/router.jsx
+++ b/public/js/react_components/router.jsx
@@ -1,9 +1,8 @@
 define(['react', 'jsx!react_components/user/_calendar', 'react-router', 
-	'jsx!react_components/group/_show', 'jsx!react_components/header/_navbar', 
-	'jsx!react_components/sidebar/_sidebar', 'jsx!react_components/calendar/_show', 
+	'jsx!react_components/group/_show', 'jsx!react_components/calendar/_show', 
 	'jsx!react_components/user/_users', 'jsx!react_components/events/_feed', 
 	'jsx!react_components/events/_show', 'jsx!react_components/events/_createEvent',
-	'jsx!react_components/user/_friendships', 'jsx!react_components/user/_user'], function(React, UserCalendar, Router, Group, Navbar, Sidebar, Calendar, Users, Feed, Event, CreateEvent, Friendships, UserPage){
+	'jsx!react_components/user/_friendships', 'jsx!react_components/user/_user'], function(React, UserCalendar, Router, Group, Calendar, Users, Feed, Event, CreateEvent, Friendships, UserPage){
 	//I can't figure out how to get RequireJS to include these at a global level
 	//so just declaring them locally here 
 	var RouteHandler = Router.RouteHandler;
@@ -11,74 +10,47 @@ define(['react', 'jsx!react_components/user/_calendar', 'react-router',
 	var Route = Router.Route;
 	var Routes = Router.Routes;
 
-	// Load FB SDK
-	window.fbAsyncInit = function() {
-	  FB.init({
-	    appId      : '751003924936029',
-	    xfbml      : true,
-	    version    : 'v2.2',
-	    status     : true
-	  });  
-	};
-	(function(d, s, id){
-	 var js, fjs = d.getElementsByTagName(s)[0];
-	 if (d.getElementById(id)) {return;}
-	 js = d.createElement(s); js.id = id;
-	 js.src = "js/vendor/fb_sdk.js";
-	 fjs.parentNode.insertBefore(js, fjs);
-	}(document, 'script', 'facebook-jssdk'));
 
-	// Setup Ajax call (all ajax calls will be authenticated)
-	$.ajaxSetup({
-	    beforeSend: function(xhr) {
-	      // var fbStatus;
-	      // FB.getLoginStatus(function(res) {
-	      //   fbStatus = res.status;
-	      // });
-	      // if ($.cookie('access_token')) {
-	        xhr.setRequestHeader("access_token", $.cookie('access_token'));
-	        xhr.setRequestHeader("user_id", $.cookie('user_id'));
-	      // } else {
-	      //   console.log("can't send data before login or your session has timed out");
-	        // localStorage.clear();
-	        // document.location.href="/";
-	        // alert("can't send data before login or your session has timed out");
-	      // }
-	    }
-	});   
+	//Prepare app -- Load App component, and ajax setup i separate files.
+	require(['app_prep/ajax_setup', 'jsx!react_components/main/app'], function( ajax_setup, App){
+	 		 
+	 	//FJ -- For the life of me I can't figure out how to just have this in a separate file
+	 	// and require it. 
+ 	 	window.fbAsyncInit = function(){
+ 	 		FB.init({
+ 				appId      : '751003924936029',
+ 				xfbml      : true,
+ 				version    : 'v2.2',
+ 				status     : true
+ 	 		}); 
+ 	 	};
+ 		(function(d, s, id){
+ 		 var js, fjs = d.getElementsByTagName(s)[0];
+ 		 if (d.getElementById(id)) {return;}
+ 		 js = d.createElement(s); js.id = id;
+ 		 js.src = "js/vendor/fb_sdk.js";
+ 		 fjs.parentNode.insertBefore(js, fjs);
+ 		}(document, 'script', 'facebook-jssdk'));
+ 		require(['app_prep/try_login']);
 
-	var App = React.createClass({
-		render: function () {
-			var style = {border: 0};
-			return(
-        <div id="container">
-					<Navbar />
-          <div id="main-container" className="row gutters">
-						<Sidebar />
-          	<div id="main-panel" className="debug col span_10 cf">
-							<RouteHandler />
-						</div>
-        	</div>
-			</div>
-			)
-		}
-	})
-	var routes = (
-		<Route handler={App}>
-			<DefaultRoute name="Feed" handler={Feed} />
-			<Route name="Groups" path="group/:id" handler={Group} />
-			<Route name="Calendar" path="calendar/:id" handler={Calendar} />
-			<Route name="Users" path="users" handler={Users} >
-				<Route name="UserCalendar" path="calendar" handler={UserCalendar} />
-				<Route name="UserPage" path=":id" handler={UserPage} />
-				<Route name="Friendships" path=":id/friendships" handler={Friendships} />
+
+		var routes = (
+			<Route handler={App}>
+				<DefaultRoute name="Feed" handler={Feed} />
+				<Route name="Groups" path="group/:id" handler={Group} />
+				<Route name="Calendar" path="calendar/:id" handler={Calendar} />
+				<Route name="Users" path="users" handler={Users} >
+					<Route name="UserCalendar" path="calendar" handler={UserCalendar} />
+					<Route name="UserPage" path=":id" handler={UserPage} />
+					<Route name="Friendships" path=":id/friendships" handler={Friendships} />
+				</Route>
+				<Route name="Event" path="event/:id" handler={Event} />
 			</Route>
-			<Route name="Event" path="event/:id" handler={Event} />
-		</Route>
-	);
+		);
 
-	Router.run(routes, function (Handler) {
-		React.render(<Handler/>, document.body);
+		Router.run(routes, function (Handler) {
+			React.render(<Handler/>, document.body);
+		});
+
 	});
-
-})
+});

--- a/public/js/react_components/sidebar/_sidebar.jsx
+++ b/public/js/react_components/sidebar/_sidebar.jsx
@@ -1,4 +1,4 @@
-define(['react', 'jquery', 'react-router','API_URL', 'stores/GroupStore', 'stores/UserStore', 'jsx!react_components/sidebar/_calendars'], function(React, $, Router, API_URL, GroupStore, UserStore, MyCalendars){
+define(['react', 'jquery', 'react-router', 'stores/GroupStore', 'stores/UserStore', 'jsx!react_components/sidebar/_calendars'], function(React, $, Router, GroupStore, UserStore, MyCalendars){
 	var Link = Router.Link;
 	function getStateFromStores(){
 		return{

--- a/public/js/react_components/user/_friendships.jsx
+++ b/public/js/react_components/user/_friendships.jsx
@@ -1,4 +1,4 @@
-define(['react', 'API_URL', 'utils/UserUtils', 'react-router', 'actions/UserViewActions'], function(React, API_URL, UserAPI, Router, UserAction) {
+define(['react', 'utils/UserUtils', 'react-router', 'actions/UserViewActions'], function(React, UserAPI, Router, UserAction) {
 	var Link = Router.Link;
 
 

--- a/public/js/react_components/user/_profile.jsx
+++ b/public/js/react_components/user/_profile.jsx
@@ -1,4 +1,4 @@
-define(['react', 'actions/CalendarActions', 'API_URL'], function(React, CalendarActions, API_URL) {
+define(['react', 'actions/CalendarActions'], function(React, CalendarActions) {
 
 	var UserProfile = React.createClass({
 		getInitialState: function() {

--- a/public/js/react_components/user/_user.jsx
+++ b/public/js/react_components/user/_user.jsx
@@ -1,4 +1,4 @@
-define(['react', 'API_URL', 'actions/UserViewActions', 'react-router', 'jsx!react_components/user/_profile'], function(React, API_URL, UserActions, Router, UserProfile) {
+define(['react', 'actions/UserViewActions', 'react-router', 'jsx!react_components/user/_profile'], function(React, UserActions, Router, UserProfile) {
 	var Link = Router.Link
 	//As of right now this page is just being loaded in with React. I think it would 
 	// be better to incorporate flux but I guess we can just leave as is until it gets more complex. 

--- a/public/js/utils/CalendarWebAPIUtils.js
+++ b/public/js/utils/CalendarWebAPIUtils.js
@@ -1,4 +1,4 @@
-define(['API_URL','actions/CalendarActions'], function(API_URL, CalendarActions){
+define(['actions/CalendarActions'], function(CalendarActions){
 
 	var CalendarAPI = {
 		initializeCals: function(){

--- a/public/js/utils/EventWebAPIUtils.js
+++ b/public/js/utils/EventWebAPIUtils.js
@@ -1,4 +1,4 @@
-define(['API_URL','actions/EventServerActions'], function(API_URL, EventServerActions){
+define(['actions/EventServerActions'], function(EventServerActions){
 
 	var EventAPI = {
 		retrieveUserEvents: function(){

--- a/public/js/utils/GroupWebAPIUtils.js
+++ b/public/js/utils/GroupWebAPIUtils.js
@@ -1,4 +1,4 @@
-define(['API_URL','actions/GroupServerActions'], function(API_URL, GroupServerActions){
+define(['actions/GroupServerActions'], function(GroupServerActions){
 	var GroupAPIs = {
 
 		retrieveSubscribedGroups: function(){


### PR DESCRIPTION
Try to login to server if localstorage has cookies. 

For the life of me I could not figure out how to break out the FB SDK to its own file. The Facebook login dialog box kept hanging. Ideally Router.jsx pretty much just has the router. 

One thing to note -- we should not be tranistioning the urls directly. We should figure out how to use React-router to transition to home page. As of now react-router is not really being incorporated with Flux but we will need to do that in order to use the router from Actions/Utils 
